### PR TITLE
fix reset of multi-value Properties

### DIFF
--- a/source/Property.ts
+++ b/source/Property.ts
@@ -397,26 +397,8 @@ export default class Property<T = any> extends Publisher
 
     reset()
     {
-        let value;
-
-        if (this.isMulti()) {
-            let multiArray: T[] = this.value as any;
-
-            if (!multiArray) {
-                value = multiArray = [] as any;
-            }
-            else {
-                multiArray.length = 1;
-            }
-
-            multiArray[0] = this.clonePreset();
-        }
-        else {
-            value = this.clonePreset();
-        }
-
         // set changed flag and push to output links
-        this.setValue(value);
+        this.setValue(this.clonePreset());
     }
 
     setMultiChannelCount(count: number)
@@ -477,7 +459,7 @@ export default class Property<T = any> extends Publisher
         return Array.isArray(this.schema.preset);
     }
 
-    isMulti(): boolean
+    isMulti(): this is Property<any[]>
     {
         return !!this.schema.multi;
     }


### PR DESCRIPTION
A property that has `multi: true` in its schema will have an initial value of `schema.preset` wrapped in an array.

It is not possible to work around this because `schema` MUST be of the property's type.

Easiest fix is to just remove this block. 

Why fix this when `schema.multi` is never used? Because I intend to use it.